### PR TITLE
wayland: update sctk-adwaita to use the master branch and add proper click duration

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4977,7 +4977,7 @@ checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
 [[package]]
 name = "sctk-adwaita"
 version = "0.10.1"
-source = "git+https://github.com/PolyMeilex/sctk-adwaita?branch=hide-titlebar#73f0c3d77ed6d3e01d2b50e2af518c7d007b545c"
+source = "git+https://github.com/PolyMeilex/sctk-adwaita?branch=master#8e4dfcd6a8d442f10aef4200515c0124173d18f2"
 dependencies = [
  "ab_glyph",
  "log",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -196,7 +196,7 @@ shlex = "1.1"
 signal-hook = "0.3"
 siphasher = "1.0.1"
 smithay-client-toolkit = {version = "0.19", default-features=false}
-sctk-adwaita = { git = "https://github.com/PolyMeilex/sctk-adwaita", branch = "hide-titlebar" }
+sctk-adwaita = { git = "https://github.com/PolyMeilex/sctk-adwaita", branch = "master" }
 smol = "2.0"
 socket2 = "0.5"
 spa = "0.3.1"

--- a/window/src/os/wayland/window.rs
+++ b/window/src/os/wayland/window.rs
@@ -312,6 +312,8 @@ impl WaylandWindow {
 
             wegl_surface: None,
             gl_state: None,
+
+            start_time: Instant::now(),
         }));
 
         let window_handle = Window::Wayland(WaylandWindow(window_id));
@@ -582,6 +584,8 @@ pub struct WaylandWindowInner {
     // libraries will segfault on shutdown
     wegl_surface: Option<WlEglSurface>,
     gl_state: Option<Rc<glium::backend::Context>>,
+    // stores the time since the window was created
+    start_time: Instant,
 }
 
 impl WaylandWindowInner {
@@ -710,13 +714,13 @@ impl WaylandWindowInner {
                     MousePress::Middle => continue,
                 };
 
-                if let Some(action) = self.window_frame.on_click(Duration::ZERO, click, pressed) {
+                let timestamp = Instant::now().duration_since(self.start_time);
+
+                if let Some(action) = self.window_frame.on_click(timestamp, click, pressed) {
                     self.frame_action(PendingMouse::last_serial(&pending_mouse), action);
                 }
             }
-            if !PendingMouse::in_window(&pending_mouse) {
-                self.window_frame.click_point_left();
-            }
+
             return;
         }
 


### PR DESCRIPTION
Fixes bug where after your first click on the title bar the window will maximize or unmaximize with every other subsequent click, because it registers it as a double click. This prevents dragging the window on desktops like Gnome.

- Changed sctk-adwaita to master since hide title bar was merged
- Set window start time and use that to pass a proper timestamp so time between clicks can be calculated properly
- Removed code that was not necessary